### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # one_dhcpd
 
 [![Hex version](https://img.shields.io/hexpm/v/one_dhcpd.svg "Hex version")](https://hex.pm/packages/one_dhcpd)
-[![API docs](https://img.shields.io/hexpm/v/one_dhcpd.svg?label=hexdocs "API docs")](https://hexdocs.pm/one_dhcpd/OneDHCPD.html)
+[![API docs](https://img.shields.io/hexpm/v/one_dhcpd.svg?label=hexdocs "API docs")](https://one-dhcpd.hexdocs.pm/OneDHCPD.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/fhunleth/one_dhcpd/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/fhunleth/one_dhcpd/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/fhunleth/one_dhcpd)](https://api.reuse.software/info/github.com/fhunleth/one_dhcpd)
 
@@ -26,5 +26,5 @@ Before using this directly, check whether you can use it via
 [`vintage_net_direct`](https://hex.pm/packages/vintage_net_direct).
 
 If you'd like to manually use this, see the [Hex
-docs](https://hexdocs.pm/one_dhcpd) for details.
+docs](https://one-dhcpd.hexdocs.pm) for details.
 

--- a/lib/one_dhcpd.ex
+++ b/lib/one_dhcpd.ex
@@ -23,7 +23,7 @@ defmodule OneDHCPD do
 
   The Nerves new project generator adds this configuration by default. If you'd
   like more information, see the
-  [VintageNetDirect[(https://hexdocs.pm/vintage_net_direct/VintageNetDirect.html)
+  [VintageNetDirect[(https://vintage-net-direct.hexdocs.pm/VintageNetDirect.html)
   documentation.
   """
   alias OneDHCPD.IPCalculator


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://one-dhcpd.hexdocs.pm/OneDHCPD.html): Status 404
❌ Verification failed for https://one-dhcpd.hexdocs.pm): %Req.TransportError{reason: :nxdomain}
❌ Verification failed for https://vintage-net-direct.hexdocs.pm/VintageNetDirect.html): Status 404
⚠️ Verification finished: 0 success, 3 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>